### PR TITLE
Added yasgui for development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -7,3 +7,10 @@ services:
   db:
     ports:
       - "8890:8890"
+  yasgui:
+    image: erikap/yasgui
+    ports:
+      - 8891:80
+    environment:
+      ENABLE_ENDPOINT_SELECTOR: "true"
+      DEFAULT_SPARQL_ENDPOINT: "http://localhost:8890/sparql"


### PR DESCRIPTION
Remember, CORS has to be enabled manually:
http://vos.openlinksw.com/owiki/wiki/VOS/VirtTipsAndTricksCORsEnableSPARQLURLs

This will be replaced by an embedded yasgui later.