### PR TITLE
Feature/zonal signs

### DIFF
--- a/config/migrations/20211512115700-zonal-concepts.graph
+++ b/config/migrations/20211512115700-zonal-concepts.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/mow/registry

--- a/config/migrations/20211512115700-zonal-concepts.ttl
+++ b/config/migrations/20211512115700-zonal-concepts.ttl
@@ -1,5 +1,4 @@
   <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ,
-      <ext:Zonality>
     <http://mu.semte.ch/vocabularies/core/uuid> "37246d14-d8ad-478c-95b1-2fd57e688b22" ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonality" .
 

--- a/config/migrations/20211512115700-zonal-concepts.ttl
+++ b/config/migrations/20211512115700-zonal-concepts.ttl
@@ -1,18 +1,19 @@
-  <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ;
+  <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ,
+      <ext:Zonality>
     <http://mu.semte.ch/vocabularies/core/uuid> "37246d14-d8ad-478c-95b1-2fd57e688b22" ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonality" .
 
-  <http://lblod.data.gift/concepts/c81c6b96-736a-48cf-b003-6f5cc3dbc55d> a <http://www.w3.org/2004/02/skos/core#Concept>;
+  <http://lblod.data.gift/concepts/c81c6b96-736a-48cf-b003-6f5cc3dbc55d> a <http://www.w3.org/2004/02/skos/core#Concept> ;
     <http://mu.semte.ch/vocabularies/core/uuid> "c81c6b96-736a-48cf-b003-6f5cc3dbc55d" ;
     <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonal" .
   
-  <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc> a <http://www.w3.org/2004/02/skos/core#Concept>;
+  <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc> a <http://www.w3.org/2004/02/skos/core#Concept> ;
     <http://mu.semte.ch/vocabularies/core/uuid> "b651931b-923c-477c-8da9-fc7dd841fdcc" ;
     <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Non-Zonal" .
     
-  <http://lblod.data.gift/concepts/8f9367b2-c717-4be7-8833-4c75bbb4ae1f> a <http://www.w3.org/2004/02/skos/core#Concept>;
+  <http://lblod.data.gift/concepts/8f9367b2-c717-4be7-8833-4c75bbb4ae1f> a <http://www.w3.org/2004/02/skos/core#Concept> ;
     <http://mu.semte.ch/vocabularies/core/uuid> "8f9367b2-c717-4be7-8833-4c75bbb4ae1f" ;
     <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Potentially Zonal" .

--- a/config/migrations/20211512115700-zonal-concepts.ttl
+++ b/config/migrations/20211512115700-zonal-concepts.ttl
@@ -1,4 +1,4 @@
-  <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ,
+  <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ;
     <http://mu.semte.ch/vocabularies/core/uuid> "37246d14-d8ad-478c-95b1-2fd57e688b22" ;
     <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonality" .
 

--- a/config/migrations/20211512115700-zonal-concepts.ttl
+++ b/config/migrations/20211512115700-zonal-concepts.ttl
@@ -1,0 +1,18 @@
+  <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> a <http://www.w3.org/2004/02/skos/core#ConceptScheme> ;
+    <http://mu.semte.ch/vocabularies/core/uuid> "37246d14-d8ad-478c-95b1-2fd57e688b22" ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonality" .
+
+  <http://lblod.data.gift/concepts/c81c6b96-736a-48cf-b003-6f5cc3dbc55d> a <http://www.w3.org/2004/02/skos/core#Concept>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "c81c6b96-736a-48cf-b003-6f5cc3dbc55d" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Zonal" .
+  
+  <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc> a <http://www.w3.org/2004/02/skos/core#Concept>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "b651931b-923c-477c-8da9-fc7dd841fdcc" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Non-Zonal" .
+    
+  <http://lblod.data.gift/concepts/8f9367b2-c717-4be7-8833-4c75bbb4ae1f> a <http://www.w3.org/2004/02/skos/core#Concept>;
+    <http://mu.semte.ch/vocabularies/core/uuid> "8f9367b2-c717-4be7-8833-4c75bbb4ae1f" ;
+    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/37246d14-d8ad-478c-95b1-2fd57e688b22> ;
+    <http://www.w3.org/2004/02/skos/core#prefLabel> "Potentially Zonal" .

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -275,6 +275,10 @@
       "class": "mobiliteit:Verkeersbordconcept",
       "super": ["concept"],
       "attributes": {
+        "zonal": {
+          "type": "boolean",
+          "predicate": "ext:isZonal"
+        },
         "image": {
           "type": "string",
           "predicate": "mobiliteit:grafischeWeergave"

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -14,6 +14,7 @@
     "qb": "http://purl.org/linked-data/cube#"
   },
   "resources": {
+    
     "resources": {
       "name": "resource",
       "class": "rdfs:Resource",
@@ -26,6 +27,7 @@
         }
       }
     },
+    
     "shapes": {
       "name": "shape",
       "class": "sh:Shape",
@@ -48,6 +50,7 @@
       },
       "new-resource-base": "http://data.lblod.info/shapes/"
     },
+    
     "property-shapes": {
       "name": "propertyShape",
       "class": "sh:PropertyShape",
@@ -61,12 +64,14 @@
       },
       "new-resource-base": "http://data.lblod.info/property-shapes/"
     },
+    
     "node-shapes": {
       "name": "nodeShape",
       "class": "sh:NodeShape",
       "super": ["shape"],
       "new-resource-base": "http://data.lblod.info/node-shapes/"
     },
+    
     "concept-schemes":{
       "name": "conceptScheme",
       "class": "skos:ConceptScheme",
@@ -90,6 +95,7 @@
       },
       "new-resource-base": "http://data.lblod.info/concept-schemes/"
     },
+    
     "code-lists": {
       "name": "codeList",
       "class": "lblodmow:Codelist",
@@ -117,6 +123,7 @@
       "features": ["include-uri"],
       "new-resource-base": "http://lblod.data.gift/concept-schemes/"
     },
+    
     "code-list-options": {
       "name": "codeListOption",
       "class": "skos:Concept",
@@ -135,6 +142,7 @@
       },
       "new-resource-base": "http://lblod.data.gift/concepts/"
     },
+    
     "concepts":{
       "name": "concept",
       "class": "ext:Concept",
@@ -159,6 +167,7 @@
       },
       "new-resource-base": "http://data.lblod.info/concepts/"
     },
+    
     "templates": {
       "name": "template",
       "class": "ext:Template",
@@ -187,6 +196,7 @@
       },
       "new-resource-base": "http://data.lblod.info/templates/"
     },
+    
     "mappings": {
       "name": "mapping",
       "class": "ext:Mapping",
@@ -220,6 +230,7 @@
       "features": ["include-uri"],
       "new-resource-base": "http://data.lblod.info/mappings/"
     },
+    
     "relations": {
       "name": "relation",
       "class": "ext:Relation",
@@ -246,18 +257,21 @@
       },
       "new-resource-base": "http://data.lblod.info/relations/"
     },
+    
     "can-be-combined-with-relations": {
       "name": "canBeCombinedWithRelation",
       "class": "ext:CanBeCombinedWithRelation",
       "super": ["relation"],
       "new-resource-base": "http://data.lblod.info/can-be-combined-with-relations/"
     },
+    
     "must-use-relations": {
       "name": "mustUseRelation",
       "class": "ext:MustUseRelation",
       "super": ["relation"],
       "new-resource-base": "http://data.lblod.info/must-use-relations/"
     },
+    
     "traffic-measure-concepts": {
       "name": "trafficMeasureConcept",
       "class": "lblodmow:TrafficMeasureConcept",
@@ -277,6 +291,7 @@
       },
       "new-resource-base": "http://data.lblod.info/traffic-measure-concepts/"
     },
+    
     "road-sign-concepts": {
       "name": "roadSignConcept",
       "class": "mobiliteit:Verkeersbordconcept",
@@ -335,6 +350,7 @@
       },
       "new-resource-base": "http://data.lblod.info/traffic-sign-concepts/"
     },
+    
     "road-marking-concepts": {
       "name": "roadMarkingConcept",
       "class": "mobiliteit:Wegmarkeringconcept",
@@ -376,6 +392,7 @@
       },
       "new-resource-base": "http://data.lblod.info/road-marking-concepts/"
     },
+    
     "traffic-light-concepts": {
       "name": "trafficLightConcept",
       "class": "mobiliteit:Verkeerslichtconcept",
@@ -417,6 +434,7 @@
       },
       "new-resource-base": "http://data.lblod.info/traffic-light-concepts/"
     },
+    
     "road-sign-categories": {
       "name": "roadSignCategory",
       "class": "mobiliteit:Verkeersbordcategorie",
@@ -436,6 +454,7 @@
       },
       "new-resource-base": "http://data.lblod.info/road-sign-categories/"
     },
+    
     "road-sign-concept-status": {
       "name": "roadSignConceptStatus",
       "class": "mobiliteit:VerkeersbordconceptStatus",
@@ -454,6 +473,7 @@
       },
       "new-resource-base": "http://data.lblod.info/road-sign-concept-status/"
     },
+    
     "road-sign-concept-status-codes": {
       "name": "roadSignConceptStatusCode",
       "class": "lblodmow:VerkeersbordconceptStatusCode",

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -268,6 +268,13 @@
           "predicate": "skos:prefLabel"
         }
       },
+      "relationships": {
+        "zonality": {
+          "predicate": "ext:zonality",
+          "target": "concept",
+          "cardinality": "one"
+        }
+      },
       "new-resource-base": "http://data.lblod.info/traffic-measure-concepts/"
     },
     "road-sign-concepts": {
@@ -275,10 +282,6 @@
       "class": "mobiliteit:Verkeersbordconcept",
       "super": ["concept"],
       "attributes": {
-        "zonal": {
-          "type": "boolean",
-          "predicate": "ext:isZonal"
-        },
         "image": {
           "type": "string",
           "predicate": "mobiliteit:grafischeWeergave"
@@ -293,6 +296,11 @@
         }
       },
       "relationships": {
+        "zonality": {
+          "predicate": "ext:zonality",
+          "target": "concept",
+          "cardinality": "one"
+        },
         "status": {
           "predicate": "vs:term_status",
           "target": "roadSignConceptStatus",


### PR DESCRIPTION
-previous migrations had naming wierdness so this does too
-added spacing to  domain so its easier to parse visually