### PR TITLE
use varnish to cache queries

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -22,7 +22,7 @@ defmodule Dispatcher do
   # SPARQL
   ###############
   match "/sparql", %{ layer: :api, accept: %{ sparql: true } } do
-    forward conn, [], "http://db:8890/sparql"
+    forward conn, [], "http://sparql-cache/sparql"
   end
 
   ###############################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  sparql-cache:
+    image: redpencil/varnish-post:1.0.0
+    environment:
+      BACKEND_HOST: db
   db:
     image: semtech/mu-authorization:0.6.0-beta.7
     environment:


### PR DESCRIPTION
Since this endpoint mostly gets the same queries over and over it makes sense to provide a caching layer. The varnish cache used has a default caching period of 30min. 
a slight delay in updates is appreciated in improved performance by caching.
We'll need to investigate if the default max document size of 2MB is sufficient for our query responses