### PR TITLE
GN-4463: addition of definition attribute to road-sign-concept model

### DIFF
--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -289,6 +289,10 @@
           "type": "string",
           "predicate": "skos:scopeNote"
         },
+        "definition": {
+          "type": "string",
+          "predicate": "skos:definition"
+        },
         "road-sign-concept-code": {
           "type": "string",
           "predicate": "skos:prefLabel"


### PR DESCRIPTION
### Overview
This PR adds a `definition` attribute to the `road-sign-concept` model in the mu-cl-resources configuration.

##### connected issues and PRs:
Solves [GN-4463](https://binnenland.atlassian.net/browse/GN-4463?atlOrigin=eyJpIjoiYmExMTAxZTdiZTg5NDA4ZmI0ZDlmNmRkNTM2MjliYzUiLCJwIjoiaiJ9) partially.

### Challenges/uncertainties
- Keeping this PR as a draft PR for now, as it is not sure yet if the `road-sign-concept` model needs a `definition` attribute (it probably will).