### PR TITLE
Update frontend to 1.4.1

### DIFF
--- a/.changeset/hungry-cooks-camp.md
+++ b/.changeset/hungry-cooks-camp.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Update frontend to 1.4.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     restart: always
     logging: *default-logging
   frontend:
-    image: lblod/frontend-mow-registry:1.4.0
+    image: lblod/frontend-mow-registry:1.4.1
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
### Overview
This PR updates the frontend to 1.4.1 (contains a fix to the URL shown in the footer)
