### PR TITLE
Remove unresolvable relationships from resource models

### DIFF
--- a/.changeset/light-wasps-change.md
+++ b/.changeset/light-wasps-change.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Drop resource relationships with unresolvable target

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -310,11 +310,6 @@
           "target": "roadSignCategory",
           "cardinality": "many"
         },
-        "measures": {
-          "predicate": "ext:measures",
-          "target": "roadMeasure",
-          "cardinality": "many"
-        },
         "subSigns": {
           "predicate": "lblodmow:heeftOnderbordConcept",
           "target": "roadSignConcept",
@@ -375,11 +370,6 @@
         }
       },
       "relationships": {
-        "status": {
-          "predicate": "vs:term_status",
-          "target": "roadMarkingConceptStatus",
-          "cardinality": "one"
-        },
         "relatedToRoadMarkingConcepts": {
           "predicate": "lblodmow:wegmarkeringHeeftGerelateerdWegmarkering",
           "target": "roadMarkingConcept",
@@ -428,16 +418,6 @@
         }
       },
       "relationships": {
-        "status": {
-          "predicate": "vs:term_status",
-          "target": "trafficLightConceptStatus",
-          "cardinality": "one"
-        },
-        "categories": {
-          "predicate": "org:classification",
-          "target": "trafficLightCategory",
-          "cardinality": "many"
-        },
         "relatedToTrafficLightConcepts": {
           "predicate": "lblodmow:verkeerslichtHeeftGerelateerdVerkeerslicht",
           "target": "trafficLightConcept",


### PR DESCRIPTION
### Overview
The recent update to `mu-cl-resources` 1.23.0 includes some changes in the handling of undefined resource models.
This PR ensures that relationships pointing to undefined models are removed.
Specifically, the following relationships have been removed:
- road-marking-concept
  * status
- traffic-light-concept
  * status
  * categories
- road-sign-concept
  * measures


These errors are probably a combination of mistakes in plurality/singularity; and copying model definitions from the MOW application.

##### connected issues and PRs:
https://github.com/lblod/app-gelinkt-notuleren/pull/178

### How to test/reproduce
- run `mu project doc` and observe that the generation of `json:api` docs executes without errors

### Challenges/uncertainties
Some of the relationships that are removed in this PR (mainly the `status` relationships) are still present in the models on the frontend, but they do not seem to be used in the frontend itself.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
