### PR TITLE
Fix data issues related to zonality URIs

### DIFF
--- a/.changeset/odd-schools-hang.md
+++ b/.changeset/odd-schools-hang.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Add migration to fill in missing zonalities of road-signs and traffic-measures

--- a/.changeset/slimy-tables-switch.md
+++ b/.changeset/slimy-tables-switch.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Add migration to fix the zonality uri used for non-zonal road-signs and traffic-measures

--- a/config/migrations/20240613085754-fix-non-zonal-uri.sparql
+++ b/config/migrations/20240613085754-fix-non-zonal-uri.sparql
@@ -1,0 +1,16 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/mow/registry> {
+    ?uri ext:zonality <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdccZ>.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/mow/registry> {
+    ?uri ext:zonality <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc>
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/mow/registry> {
+    ?uri ext:zonality <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdccZ>
+  }
+}

--- a/config/migrations/20240613090626-fill-in-missing-zonalities.sparql
+++ b/config/migrations/20240613090626-fill-in-missing-zonalities.sparql
@@ -1,0 +1,13 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodMobilitiet: <http://data.lblod.info/vocabularies/mobiliteit/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/mow/registry> {
+    ?uri ext:zonality <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc>
+  }
+} WHERE {
+  ?uri a ?type.
+  FILTER NOT EXISTS { ?uri ext:zonality ?zonality }
+  FILTER(?type IN (mobiliteit:Verkeersbordconcept, lblodMobilitiet:TrafficMeasureConcept))
+}


### PR DESCRIPTION
### Overview
This PR fixes two data issues related to the zonality of road-signs/traffic-measures:
- Fill-in of missing zonalities of road-signs and traffic-measures
- Fix a typo in the usage of the non-zonal URI (http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdccZ> to 
http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc)

##### connected issues and PRs:
None

### How to test/reproduce
- Start the application
- Ensure (when querying with sparql) there are no missing zonalities and the correct zonality URIs are used

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
