### PR TITLE
add hacky workaround to ensure road-sign and traffic-light concepts can be correctly consumed

### DIFF
--- a/.changeset/polite-ways-talk.md
+++ b/.changeset/polite-ways-talk.md
@@ -1,0 +1,7 @@
+---
+"app-mow-registry": patch
+---
+
+Add hacky workaround to ensure road-marking and traffic-light concepts can be correctly consumed:
+- Addition of a migration which adds default zonalities to traffic-light and road-marking concepts
+- Add `zonality` relationship to traffic-light and road-marking concepts in JSON-API definitions

--- a/config/migrations/20240620115606-fill-in-missing-zonalities-workaround.sparql
+++ b/config/migrations/20240620115606-fill-in-missing-zonalities-workaround.sparql
@@ -1,0 +1,13 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX lblodMobilitiet: <http://data.lblod.info/vocabularies/mobiliteit/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/mow/registry> {
+    ?uri ext:zonality <http://lblod.data.gift/concepts/b651931b-923c-477c-8da9-fc7dd841fdcc>
+  }
+} WHERE {
+  ?uri a ?type.
+  FILTER NOT EXISTS { ?uri ext:zonality ?zonality }
+  FILTER(?type IN (mobiliteit:Wegmarkeringconcept, mobiliteit:Verkeerslichtconcept, mobiliteit:Verkeersbordconcept, lblodMobilitiet:TrafficMeasureConcept))
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -391,6 +391,11 @@
           "target": "trafficLightConcept",
           "cardinality": "many",
           "inverse": true
+        },
+        "zonality":{
+          "predicate": "ext:zonality",
+          "target": "skosConcept",
+          "cardinality": "one"
         }
       },
       "new-resource-base": "http://data.lblod.info/road-marking-concepts/"
@@ -438,6 +443,11 @@
           "predicate": "lblodmow:verkeerslichtHeeftGerelateerdWegmarkering",
           "target": "roadMarkingConcept",
           "cardinality": "many"
+        },
+        "zonality":{
+          "predicate": "ext:zonality",
+          "target": "skosConcept",
+          "cardinality": "one"
         }
       },
       "new-resource-base": "http://data.lblod.info/traffic-light-concepts/"


### PR DESCRIPTION
### Overview
Add hacky workaround to ensure road-marking and traffic-light concepts can be correctly consumed:
- Addition of a migration which adds default zonalities to traffic-light and road-marking concepts
- Add `zonality` relationship to traffic-light and road-marking concepts in JSON-API definitions
