### PR TITLE
remove definition from backend

### DIFF
--- a/config/migrations/20240806110449-remove-definitions.sparql
+++ b/config/migrations/20240806110449-remove-definitions.sparql
@@ -1,0 +1,13 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+    GRAPH ?g {
+        ?s skos:definition ?o
+    }
+}
+
+WHERE {
+    GRAPH ?g {
+        ?s skos:definition ?o
+    }
+} 

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -418,12 +418,7 @@
       "name": "roadMarkingConcept",
       "class": "mobiliteit:Wegmarkeringconcept",
       "super": ["trafficSignConcept"],
-      "attributes": {
-        "definition": {
-          "type": "string",
-          "predicate": "skos:definition"
-        }
-      },
+      "attributes": {},
       "relationships": {
         "relatedToRoadMarkingConcepts": {
           "predicate": "lblodmow:wegmarkeringHeeftGerelateerdWegmarkering",
@@ -459,12 +454,7 @@
       "name": "trafficLightConcept",
       "class": "mobiliteit:Verkeerslichtconcept",
       "super": ["trafficSignConcept"],
-      "attributes": {
-        "definition": {
-          "type": "string",
-          "predicate": "skos:definition"
-        }
-      },
+      "attributes": {},
       "relationships": {
         "relatedToTrafficLightConcepts": {
           "predicate": "lblodmow:verkeerslichtHeeftGerelateerdVerkeerslicht",


### PR DESCRIPTION
### Overview
Remove definition attribute from:
- road marking concepts
- traffic light concepts

##### connected issues and PRs:
<!-- links to connected jira tickets -->
https://binnenland.atlassian.net/browse/GN-4971
<!-- Link to PRs that are related (and in what way) -->
frontend: https://github.com/lblod/frontend-mow-registry/pull/264
