### PR TITLE
[GN-5070] Remove the hardcoded `Traffic measure` suffix from the labels in the DB

### DIFF
--- a/config/migrations/20241002151500-trim-traffic-measure-labels.sparql
+++ b/config/migrations/20241002151500-trim-traffic-measure-labels.sparql
@@ -1,0 +1,22 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?s skos:prefLabel ?oldLabel .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s skos:prefLabel ?newLabel .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a mobiliteit:Mobiliteitmaatregelconcept ;
+        skos:prefLabel ?oldLabel .
+  }
+  BIND( IF(STRENDS(?oldLabel, " Traffic Measure"),
+            REPLACE(?oldLabel, " Traffic Measure$", ""),
+            ?oldLabel) AS ?newLabel ) .
+}


### PR DESCRIPTION
We now display the suffix in the frontend where needed.