### PR TITLE
fix ldes delta pusher version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,7 @@ services:
   ################################################################################
 
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:latest
+    image: redpencil/ldes-delta-pusher:0.4.1
     environment:
       LDES_ENDPOINT: "http://ldes-backend/ldes-mow-register"
     volumes:


### PR DESCRIPTION
latest version of the ldes-delta-pusher service has many changes that broke our current configuration.
I've fixed the version to 0.4.1 for now (in the override), so that it unblocks external testers / implementers.