### PR TITLE
Migrate variable title to value

### DIFF
--- a/config/migrations/20241206121500-variable-title-to-value.sparql
+++ b/config/migrations/20241206121500-variable-title-to-value.sparql
@@ -1,0 +1,20 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+DELETE {
+  GRAPH ?g {
+    ?s dct:title ?value .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s rdf:value ?value .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a mobiliteit:Variabele;
+      dct:title ?value.
+  }
+}


### PR DESCRIPTION
In previous migration, `ext:variable` were migrated into `dct:title` instead of value. https://github.com/lblod/app-mow-registry/blob/version/2.0.0/config/migrations/20240730174403-mapping-to-variable.sparql#L48-L66

This PR add a migration to migrate `dct:title` into `rdf:value`. 