### PR TITLE
Fix Template predicate

### DIFF
--- a/config/migrations/20241206131500-fix-template-variable.sparql
+++ b/config/migrations/20241206131500-fix-template-variable.sparql
@@ -1,0 +1,42 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+
+DELETE {
+    GRAPH ?g {
+        ?s ext:mapping ?o
+    }
+}
+
+INSERT {
+    GRAPH ?g {
+        ?s mobiliteit:variabele ?o
+    }
+}
+
+WHERE {
+    GRAPH ?g {
+        ?s a mobiliteit:Template ;
+        ext:mapping ?o
+    }
+}
+
+;
+
+DELETE {
+    GRAPH ?g {
+        ?s ext:template ?o
+    }
+}
+
+INSERT {
+    GRAPH ?g {
+        ?s mobiliteit:template ?o
+    }
+}
+
+WHERE {
+    GRAPH ?g {
+        ?s a mobiliteit:Template ;
+        ext:template ?o
+    }
+}


### PR DESCRIPTION
- The predicate migrations on `ext:Template` in https://github.com/lblod/app-mow-registry/blob/version/2.0.0/config/migrations/20240730174403-mapping-to-variable.sparql#L6-L46 has no effect. 
- Due to a previous template type migration https://github.com/lblod/app-mow-registry/blob/version/2.0.0/config/migrations/20240429115806-migration-to-oslo-template.sparql#L8-L22

The missing migration is now applied on the new `mobiliteit:Template` type. 