### PR TITLE
Prevent restart of services on developer machines

### DIFF
--- a/.changeset/chilly-squids-leave.md
+++ b/.changeset/chilly-squids-leave.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Add restart configurations to dev services to prevent restarting on developer machines

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,10 @@
-version: "3.4"
-
 services:
   identifier:
+    restart: "no"
     ports:
       - "80:80"
+  dispatcher:
+    restart: "no"
   triplestore:
     ports:
       - "8890:8890"
@@ -26,3 +27,29 @@ services:
       SITE_ADDRESS: "roadsigns.lblod.info"
     volumes:
       - ./config/dev/tlsproxy/Caddyfile:/etc/caddy/Caddyfile
+  sparql-cache:
+    restart: "no"
+  db:
+    restart: "no"
+  migrations:
+    restart: "no"
+  resource:
+    restart: "no"
+  cache:
+    restart: "no"
+  file:
+    restart: "no"
+  frontend:
+    restart: "no"
+  static-file:
+    restart: "no"
+  login:
+    restart: "no"
+  ldes-delta-pusher:
+    restart: "no"
+  ldes-backend:
+    restart: "no"
+  tombstone:
+    restart: "no"
+  deltanotifier:
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 x-logging: &default-logging
   driver: "json-file"
   options:
@@ -163,6 +161,7 @@ services:
     image: lblod/tombstone-service
     links:
       - db:database
+    restart: always
   deltanotifier:
     image: cecemel/delta-notifier:0.2.0-beta.2
     volumes:


### PR DESCRIPTION
### Overview
~~Also remove use of unpinned frontend version as it could cause local testing inconsistencies and isn't the correct way to test new versions locally.~~
Also add a restart configuration for the tombstone service in production.

##### connected issues and PRs:
N/A

### Setup
N/A

### How to test/reproduce
Restart your docker daemon and notice the services don't get automatically started.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
