### PR TITLE
variables: replace `rdf:value` by `dct:title`

### DIFF
--- a/.changeset/curvy-cobras-agree.md
+++ b/.changeset/curvy-cobras-agree.md
@@ -1,5 +1,0 @@
----
-"app-mow-registry": patch
----
-
-update fix-annotation-service to 3.0.0

--- a/.changeset/large-feet-double.md
+++ b/.changeset/large-feet-double.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Variables: replace `rdf:value` by more appropriate `dct:title` to represent the label/title of a variable

--- a/.changeset/sharp-trees-smash.md
+++ b/.changeset/sharp-trees-smash.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Update `annotater` service to version [4.0.0](https://github.com/lblod/fix-annotation-service/releases/tag/v4.0.0)

--- a/.changeset/smooth-chicken-happen.md
+++ b/.changeset/smooth-chicken-happen.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Remove support for `annotated` property of `template` resource and add support for `preview` property

--- a/config/migrations/20250128130820-variable-value-to-label.sparql
+++ b/config/migrations/20250128130820-variable-value-to-label.sparql
@@ -1,0 +1,21 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?g {
+    ?variable rdf:value ?label.
+  }
+}
+INSERT {
+  GRAPH ?g {
+  	?variable dct:title ?label.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?variable a mobiliteit:Variabele.
+    ?variable rdf:value ?label.
+  }
+}

--- a/config/migrations/20250130151407-drop-annotated-templates.sparql
+++ b/config/migrations/20250130151407-drop-annotated-templates.sparql
@@ -1,0 +1,14 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+
+DELETE {
+  GRAPH ?g {
+    ?template ext:annotated ?annotated.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?template a mobiliteit:Template ;
+              ext:annotated ?annotated.
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -194,9 +194,9 @@
           "type": "string",
           "predicate": "prov:value"
         },
-        "annotated": {
+        "preview": {
           "type": "string",
-          "predicate": "ext:annotated"
+          "predicate": "ext:preview"
         }
       },
       "relationships": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -226,10 +226,6 @@
           "type": "string",
           "predicate": "dct:type"
         },
-        "value": {
-          "type": "string",
-          "predicate": "rdf:value"
-        },
         "defaultValue": {
           "type": "string",
           "predicate": "mobiliteit:standaardwaarde"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - ./scripts/:/app/scripts/
     restart: "no"
   annotater:
-    image: lblod/fix-annotation-service:3.0.0
+    image: lblod/fix-annotation-service:4.0.0
     environment:
       SPARQL_ENDPOINT: https://roadsigns.lblod.info/sparql
     restart: "no"


### PR DESCRIPTION
### Overview
This PR slightly adjust the variable data-model to use the `dct:title` predicate instead of the `rdf:value` predicate to represent the label/title of a variable:
- A migration is included to replace instances of `rdf:value` by `dct:title`
- The `rdf:value` property has been removed from the mu-cl-resources variable data-model

##### connected issues and PRs:
https://github.com/lblod/fix-annotation-service/pull/16
https://github.com/lblod/frontend-mow-registry/pull/314

### Setup
Include both https://github.com/lblod/fix-annotation-service/pull/16 and https://github.com/lblod/frontend-mow-registry/pull/314 in your stack:

```yml
  frontend:
    image: !reset null
    build: https://github.com/lblod/frontend-mow-registry.git#fix/variable-value-to-label
  annotater:
    image: !reset null
    build: https://github.com/lblod/fix-annotation-service.git#fix/variable-value-to-label
```


### How to test/reproduce
- Ensure every functionality related to variables/instructions still works
- Ensure that the `label` of a variable is used, and not its `value`
- Ensure that, when querying the DB, not variables with `rdf:value` are found, and the `dct:title` predicate should be defined.
- The generated annotated templates should now contain an `dct:title` property instead of `rdf:value`

### Challenges/uncertainties
- We'll probably want to run the `/update-all` endpoint on deployed envs to regenerate all annotated templates.
- This PR is a draft until both the service and frontend PRs are merged.

### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
