### PR TITLE
feat(templates): introduce support for template previews

### DIFF
--- a/.changeset/smooth-chicken-happen.md
+++ b/.changeset/smooth-chicken-happen.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Remove support for `annotated` property of `template` resource and add support for `preview` property

--- a/config/migrations/20250130151407-drop-annotated-templates.sparql
+++ b/config/migrations/20250130151407-drop-annotated-templates.sparql
@@ -1,0 +1,14 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+
+DELETE {
+  GRAPH ?g {
+    ?template ext:annotated ?annotated.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?template a mobiliteit:Template ;
+              ext:annotated ?annotated.
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -194,9 +194,9 @@
           "type": "string",
           "predicate": "prov:value"
         },
-        "annotated": {
+        "preview": {
           "type": "string",
-          "predicate": "ext:annotated"
+          "predicate": "ext:preview"
         }
       },
       "relationships": {


### PR DESCRIPTION
### Overview
This PR includes support for template previews.
Specifically:
- The `annotated` property of the `template` model has been removed
- A `preview` property has been added to the `template` model

##### connected issues and PRs:
https://github.com/lblod/frontend-mow-registry/pull/315
https://github.com/lblod/fix-annotation-service/pull/17


### Setup
Include both https://github.com/lblod/frontend-mow-registry/pull/315 and https://github.com/lblod/fix-annotation-service/pull/17 in your stack:
```yml
  frontend:
    image: !reset null
    build: https://github.com/lblod/frontend-mow-registry.git#feat/template-previews
  annotater:
    image: !reset null
    build: https://github.com/lblod/fix-annotation-service.git#feat/template-previews
```

### How to test/reproduce
- Start the stack
- Ensure the migration runs correctly
- (Optional) call the `/update-all` endpoint of the `annotater` service to generate a preview for all templates in the database.
- Open the frontend
- Open/create some roadsign concepts and add some instructions
- Open/create some mobility measure concepts. Add variables, as well as instructions to these measure concepts
- Ensure that you can now search on the full text of mobility measure templates (the preview generation should happen near-instantly)
- Looking at the triplestore, `ext:preview` relationships should now be defined on the templates.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
