### PR TITLE
Use correct predicate to represent template value/content

### DIFF
--- a/.changeset/chatty-mails-visit.md
+++ b/.changeset/chatty-mails-visit.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Update `annotater` to version [4.1.0](https://github.com/lblod/fix-annotation-service/releases/tag/v4.1.0)

--- a/.changeset/new-lemons-fix.md
+++ b/.changeset/new-lemons-fix.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Replace `prov:value` by `rdf:value` on `mobiliteit:Template` resources. This ensures it is correctly following the `mobiliteit` data model.

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -50,7 +50,7 @@ export default [
     match: {
       predicate: {
         type: 'uri',
-        value: 'http://www.w3.org/ns/prov#value'
+        value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#value'
       }
     },
     callback: {

--- a/config/migrations/20250205105230-fix-template-value-predicate.sparql
+++ b/config/migrations/20250205105230-fix-template-value-predicate.sparql
@@ -1,0 +1,21 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
+
+DELETE {
+  GRAPH ?g {
+    ?uri prov:value ?value.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?uri rdf:value ?value.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?uri 
+      a mobiliteit:Template;
+      prov:value ?value.
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -10,6 +10,7 @@
     "sh": "http://www.w3.org/ns/shacl#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "qb": "http://purl.org/linked-data/cube#",
     "besluit": "https://data.vlaanderen.be/ns/besluit#",
@@ -18,7 +19,6 @@
     "icb": "https://w3id.org/isCharacterisedBy#",
     "foaf": "http://xmlns.com/foaf/0.1/",
     "qudt": "http://qudt.org/schema/qudt/",
-    "prov": "http://www.w3.org/ns/prov#",
     "variables": "http://lblod.data.gift/vocabularies/variables/"
   },
   "resources": {
@@ -193,7 +193,7 @@
       "attributes": {
         "value": {
           "type": "string",
-          "predicate": "prov:value"
+          "predicate": "rdf:value"
         },
         "preview": {
           "type": "string",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - ./scripts/:/app/scripts/
     restart: "no"
   annotater:
-    image: lblod/fix-annotation-service:4.0.0
+    image: lblod/fix-annotation-service:4.1.0
     environment:
       SPARQL_ENDPOINT: https://roadsigns.lblod.info/sparql
     restart: "no"


### PR DESCRIPTION
### Overview
This PR ensures the correct predicate (`rdf:value`) is used to represent the value of `mobiliteit:Template` resources (coming from `prov:value`).

##### connected issues and PRs:
https://github.com/lblod/fix-annotation-service/pull/19

### Setup
Include https://github.com/lblod/fix-annotation-service/pull/19 in your stack:
```yml
annotater:
  image: !reset null
  build: https://github.com/lblod/fix-annotation-service.git#fix/template-value
```

### How to test/reproduce
- Start the triplestore & migrations. Ensure the migrations ran correctly
- Start the rest of the stack
- Ensure `prov:value` is no longer used in the triplestore
- Ensure the frontend still works correctly
- Ensure the `annotater` service does its job.

### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
