### PR TITLE
fix: add missing prefix to `init-ldes-data` script

### DIFF
--- a/.changeset/cuddly-lies-lick.md
+++ b/.changeset/cuddly-lies-lick.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Add missing prefix to SPARQL query in `init-ldes-data` mu-script

--- a/scripts/init-ldes-data/app.mjs
+++ b/scripts/init-ldes-data/app.mjs
@@ -109,6 +109,7 @@ async function getGraphTriples(page, limit) {
     PREFIX cidoc: <http://www.cidoc-crm.org/cidoc-crm/>
     PREFIX tribont: <https://w3id.org/tribont/core#>
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+    PREFIX variables: <http://lblod.data.gift/vocabularies/variables/>
 
     CONSTRUCT {?s ?p ?o} WHERE
     {


### PR DESCRIPTION
### Overview
This PR adds the missing `variables` prefix to to a SPARQL query in the `init-ldes-data` script

### How to test/reproduce
- Execute the `init-ldes-data` mu script and ensure it succeeds