### PR TITLE
expose raw-sparql endpoint

### DIFF
--- a/.changeset/small-jeans-deliver.md
+++ b/.changeset/small-jeans-deliver.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Expose raw-sparql endpoint

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -25,6 +25,10 @@ defmodule Dispatcher do
     forward conn, [], "http://sparql-cache/sparql"
   end
 
+  match "/raw-sparql", %{ layer: :api, accept: %{ sparql: true } } do
+    forward conn, [], "http://db:8890/sparql"
+  end
+
   ###############################################################
   # domain.json
   ###############################################################


### PR DESCRIPTION
### Overview
Expose raw-sparql endpoint for the validity dates

##### connected issues and PRs:
GN-2702


### Setup
None

### How to test/reproduce
Notice you can now send sparql queries without cache to /raw-sparql

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
