### PR TITLE
setup ldes autohealing

### DIFF
--- a/.changeset/silent-garlics-join.md
+++ b/.changeset/silent-garlics-join.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Add autohealing to the ldes stream

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -63,4 +63,20 @@ export default [
       gracePeriod: 250,
     },
   },
+  {
+    match: {
+      subject: {},
+    },
+    callback: {
+      url: "http://modified/delta",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 10000,
+      retry: 3,
+      ignoreFromSelf: true,
+      retryTimeout: 250,
+    },
+  },
 ];

--- a/config/ldes-delta-pusher/healing.ts
+++ b/config/ldes-delta-pusher/healing.ts
@@ -1,0 +1,82 @@
+export type HealingConfig = Awaited<ReturnType<typeof getHealingConfig>>;
+export const getHealingConfig = async () => {
+  return {
+    // this is the name of a stream, you can have multiple streams in the config,
+    // the healing process will check them one by one sequentially
+    "ldes-mow-register": {
+      entities: {
+        "http://www.cidoc-crm.org/cidoc-crm/E54_Dimension": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://qudt.org/schema/qudt/Unit": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://qudt.org/schema/qudt/QuantityKind": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://mu.semte.ch/vocabularies/ext/ShapeClassificatieCode": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://xmlns.com/foaf/0.1/Document": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://mu.semte.ch/vocabularies/ext/Concept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://xmlns.com/foaf/0.1/Image": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://www.w3.org/ns/activitystreams#Tombstone": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://data.lblod.info/vocabularies/mobiliteit/Codelist": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://data.lblod.info/vocabularies/mobiliteit/VerkeersbordconceptStatusCode":
+          ["http://purl.org/dc/terms/modified"],
+        "https://data.vlaanderen.be/ns/mobiliteit#Mobiliteitmaatregelconcept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Pictogram": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Template": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://lblod.data.gift/vocabularies/variables/Variable": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordcategorie": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#VerkeersbordconceptStatus": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Verkeerslichtconcept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Verkeerstekenconcept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://data.vlaanderen.be/ns/mobiliteit#Wegmarkeringconcept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://www.w3.org/2000/01/rdf-schema#Resource": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://www.w3.org/2004/02/skos/core#Concept": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "http://www.w3.org/2004/02/skos/core#ConceptScheme": [
+          "http://purl.org/dc/terms/modified",
+        ],
+        "https://w3id.org/tribont/core#Shape": [
+          "http://purl.org/dc/terms/modified",
+        ],
+      },
+    },
+  };
+};

--- a/config/migrations/20250324154000-clear-multiple-modified-dates.sparql
+++ b/config/migrations/20250324154000-clear-multiple-modified-dates.sparql
@@ -1,0 +1,11 @@
+DELETE {
+GRAPH ?g {
+?a <http://purl.org/dc/terms/modified> ?c.
+}
+}where {
+GRAPH ?g {
+?a <http://purl.org/dc/terms/modified> ?b.
+?a <http://purl.org/dc/terms/modified> ?c.
+}
+Filter(?b > ?c)
+}

--- a/config/modified/config.ts
+++ b/config/modified/config.ts
@@ -1,3 +1,5 @@
+import { Changeset } from "../types";
+
 export const interestingTypes = [
   "http://www.cidoc-crm.org/cidoc-crm/E54_Dimension",
   "http://qudt.org/schema/qudt/Unit",

--- a/config/modified/config.ts
+++ b/config/modified/config.ts
@@ -1,0 +1,50 @@
+export const interestingTypes = [
+  "http://www.cidoc-crm.org/cidoc-crm/E54_Dimension",
+  "http://qudt.org/schema/qudt/Unit",
+  "http://qudt.org/schema/qudt/QuantityKind",
+  "http://mu.semte.ch/vocabularies/ext/ShapeClassificatieCode",
+  "http://xmlns.com/foaf/0.1/Document",
+  "http://mu.semte.ch/vocabularies/ext/Concept",
+  "http://xmlns.com/foaf/0.1/Image",
+  "https://www.w3.org/ns/activitystreams#Tombstone",
+  "http://data.lblod.info/vocabularies/mobiliteit/Codelist",
+  "http://data.lblod.info/vocabularies/mobiliteit/VerkeersbordconceptStatusCode",
+  "https://data.vlaanderen.be/ns/mobiliteit#Mobiliteitmaatregelconcept",
+  "https://data.vlaanderen.be/ns/mobiliteit#Pictogram",
+  "https://data.vlaanderen.be/ns/mobiliteit#Template",
+  "http://lblod.data.gift/vocabularies/variables/Variable",
+  "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordcategorie",
+  "https://data.vlaanderen.be/ns/mobiliteit#Verkeersbordconcept",
+  "https://data.vlaanderen.be/ns/mobiliteit#VerkeersbordconceptStatus",
+  "https://data.vlaanderen.be/ns/mobiliteit#Verkeerslichtconcept",
+  "https://data.vlaanderen.be/ns/mobiliteit#Verkeerstekenconcept",
+  "https://data.vlaanderen.be/ns/mobiliteit#Wegmarkeringconcept",
+  "http://www.w3.org/2000/01/rdf-schema#Resource",
+  "http://www.w3.org/2004/02/skos/core#Concept",
+  "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+  "https://w3id.org/tribont/core#Shape",
+];
+
+export const filterModifiedSubjects = "";
+
+export async function filterDeltas(changeSets: Changeset[]) {
+  const modifiedPred = "http://purl.org/dc/terms/modified";
+  const subjectsWithModified = new Set();
+
+  const trackModifiedSubjects = (quad) => {
+    if (quad.predicate.value === modifiedPred) {
+      subjectsWithModified.add(quad.subject.value);
+    }
+  };
+  changeSets.forEach((changeSet) => {
+    changeSet.inserts.forEach(trackModifiedSubjects);
+  });
+
+  const isGoodQuad = (quad) => !subjectsWithModified.has(quad.subject.value);
+  return changeSets.map((changeSet) => {
+    return {
+      inserts: changeSet.inserts.filter(isGoodQuad),
+      deletes: changeSet.deletes.filter(isGoodQuad),
+    };
+  });
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     restart: always
     logging: *default-logging
   triplestore:
-    image: redpencil/virtuoso:1.0.0
+    image: redpencil/virtuoso:1.2.0
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
@@ -147,7 +147,7 @@ services:
     restart: always
 
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:1.2.2
+    image: redpencil/ldes-delta-pusher:1.2.4
     environment:
       CRON_HEALING: "0 0 0 * * *" # Every day at midnight
       AUTO_HEALING: "true"
@@ -159,6 +159,7 @@ services:
       CACHE_SIZE: "1000"
       DATA_FOLDER: "/ldes/ldes-feed"
       LDES_FOLDER: "ldes-mow-register"
+      VIRTUOSO_DATE_WORKAROUND: "true"
     volumes:
       - ./config/ldes-delta-pusher:/config
       - ./data/ldes-feed:/ldes/ldes-feed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,8 +147,10 @@ services:
     restart: always
 
   ldes-delta-pusher:
-    image: redpencil/ldes-delta-pusher:1.2.0
+    image: redpencil/ldes-delta-pusher:1.2.2
     environment:
+      CRON_HEALING: "0 0 0 * * *" # Every day at midnight
+      AUTO_HEALING: "true"
       LDES_BASE: "https://dev-vlag.roadsigns.lblod.info/"
       FOLDER_DEPTH: "1"
       PAGE_RESOURCES_COUNT: "50"
@@ -180,3 +182,15 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  
+  modified:
+    image: lblod/track-modified-service:0.0.1
+    labels:
+      - "logging=true"
+    volumes:
+      - ./config/modified:/config
+    links:
+      - db:database
+    restart: always
+    logging: *default-logging
+


### PR DESCRIPTION
### Overview
Setup autohealing for the ldes stream, for this I had to also add the modified service which is a service that add a dct:modified to the ldes types.

##### connected issues and PRs:
GN-5449


### Setup
None

### How to test/reproduce
Weird one to test, basically you can modify a ldes type, for example a roadsign, go to the ldes ttl file, delete that change, then run the healing (by changing the cronjob pattern in the docker compose) and then check that your change was restored

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
