### PR TITLE
Pin `lblod/ldes-serve-feed-service` to version 0.1.0

### DIFF
--- a/.changeset/sharp-rats-fly.md
+++ b/.changeset/sharp-rats-fly.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Pin the `lblod/ldes-serve-feed` service to version 0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
   ################################################################################
 
   ldes-serve-feed:
-    image: lblod/ldes-serve-feed-service
+    image: lblod/ldes-serve-feed-service:0.1.0
     environment:
       BASE_URL: "https://dev-vlag.roadsigns.lblod.info/"
       LDES_STREAM_PREFIX: "http://data.lblod.info/streams/op/"


### PR DESCRIPTION
### Overview
This PR updates and pins the `lblod/ldes-serve-feed-service` to version [0.1.0](https://github.com/lblod/ldes-serve-feed-service/releases/tag/v0.1.0).