### PR TITLE
increase grace period to 15sec

### DIFF
--- a/.changeset/late-roses-retire.md
+++ b/.changeset/late-roses-retire.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Increase grace period for ldes deltas

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -39,11 +39,7 @@ export default [
     options: {
       resourceFormat: "v0.0.1",
       ignoreFromSelf: false,
-      optOutMuScopeIds: [
-        "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
-        "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance",
-      ],
-      gracePeriod: 1000,
+      gracePeriod: 15000,
     },
   },
   {


### PR DESCRIPTION
GN-5566

The MOW registry makes 15 requests to save a measure. If the total time for all of these requests exceeds one second, the ldes delta pusher may generate invalid data, because it still checks the triplestore to determine which information is currently active. By substantially increasing the grace period, we can find a stable point where the ldes delta pusher  is more likely to produce correct information. 

https://github.com/user-attachments/assets/5ec21435-6f5f-4597-85b7-d4533edf2e6a

