### PR TITLE
Fix template property to differentiate variable and mobility measure

### DIFF
--- a/.changeset/lemon-dots-tie.md
+++ b/.changeset/lemon-dots-tie.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": major
+---
+
+MODEL BREAKING: changed Mobiliteitmaatregelconcept relationship to template from mobiliteit:template to mobiliteit:Mobiliteitsmaatregelconcept.template

--- a/config/migrations/20250523105700-change-template-property.sparql
+++ b/config/migrations/20250523105700-change-template-property.sparql
@@ -1,0 +1,8 @@
+DELETE {
+    ?uri mobiliteit:template ?template.
+} INSERT {
+    ?uri mobiliteit:Mobiliteitsmaatregelconcept.template ? template.
+} WHERE {
+    ?uri a mobiliteit:Mobiliteitmaatregelconcept;
+        mobiliteit:template ?template.
+}

--- a/config/migrations/20250523105700-change-template-property.sparql
+++ b/config/migrations/20250523105700-change-template-property.sparql
@@ -1,8 +1,15 @@
+PREFIX mobiliteit: <https://data.vlaanderen.be/ns/mobiliteit#>
 DELETE {
-    ?uri mobiliteit:template ?template.
+    GRAPH ?g {
+        ?uri mobiliteit:template ?template.
+    }
 } INSERT {
-    ?uri mobiliteit:Mobiliteitsmaatregelconcept.template ? template.
+    GRAPH ?g {
+        ?uri mobiliteit:Mobiliteitsmaatregelconcept.template ?template.
+    }
 } WHERE {
-    ?uri a mobiliteit:Mobiliteitmaatregelconcept;
-        mobiliteit:template ?template.
+    GRAPH ?g {
+        ?uri a mobiliteit:Mobiliteitmaatregelconcept;
+            mobiliteit:template ?template.
+    }
 }

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -210,7 +210,7 @@
           "cardinality": "many"
         },
         "parentConcept": {
-          "predicate": "mobiliteit:template",
+          "predicate": "mobiliteit:Mobiliteitsmaatregelconcept.template",
           "target": "trafficMeasureConcept",
           "cardinality": "one",
           "inverse": true
@@ -370,7 +370,7 @@
           "cardinality": "one"
         },
         "template": {
-          "predicate": "mobiliteit:template",
+          "predicate": "mobiliteit:Mobiliteitsmaatregelconcept.template",
           "target": "template",
           "cardinality": "one"
         },


### PR DESCRIPTION
### Overview
A template couldn't be linked to 2 variables, due to the model constraint of the inverse parentConceptOf linked to a mobility measure.
After talking with Niels we decided to separate this 2 properties.
Warning: this affects consuming apps so we should deploy the changes in sync

##### connected issues and PRs:
GN-5596


### Setup
None

### How to test/reproduce
Check that you can add a instruction variable linked with the same template in 2 different measures

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
