### PR TITLE
GN-5546: add support for adding shapes to road-marking-concepts

### DIFF
--- a/.changeset/cold-ligers-perform.md
+++ b/.changeset/cold-ligers-perform.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Move `icb:isCharacterisedBy` shapes relationship from `road-sign-concept` to `traffic-sign-concept` class

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -420,6 +420,11 @@
           "target": "variable",
           "cardinality": "many"
         },
+        "shapes": {
+          "predicate": "icb:isCharacterisedBy",
+          "target": "tribontShape",
+          "cardinality": "many"
+        },
         "status": {
           "predicate": "vs:term_status",
           "target": "skosConcept",
@@ -457,11 +462,6 @@
         "classifications": {
           "predicate": "dct:type",
           "target": "roadSignCategory",
-          "cardinality": "many"
-        },
-        "shapes": {
-          "predicate": "icb:isCharacterisedBy",
-          "target": "tribontShape",
           "cardinality": "many"
         },
         "subSigns": {


### PR DESCRIPTION
### Overview
This PR moves the `shapes` relationship from the `road-sign-concept` class to the parent `traffic-sign-concept` class. This is needed to also support shapes for road-marking-concepts.

##### connected issues and PRs:
[GN-5546](https://binnenland.atlassian.net/browse/GN-5546?atlOrigin=eyJpIjoiM2I5ZjQwNmY2ZmY3NDkxMWFkZGIwM2ZiYjI0NmFjNzQiLCJwIjoiaiJ9)
https://github.com/lblod/frontend-mow-registry/pull/329

### How to test/reproduce
Check-out https://github.com/lblod/frontend-mow-registry/pull/329

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
