### PR TITLE
Rename traffic sign to traffic signal

### DIFF
--- a/.changeset/sixty-goats-accept.md
+++ b/.changeset/sixty-goats-accept.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Rename super-class of road signs, road markings and traffic lights to 'traffic signal' to more closely match the original Dutch 'verkeersteken'

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -374,17 +374,17 @@
           "target": "template",
           "cardinality": "one"
         },
-        "relatedTrafficSignConcepts": {
+        "relatedTrafficSignalConcepts": {
           "predicate": "mobiliteit:heeftMaatregelconcept",
-          "target": "trafficSignConcept",
+          "target": "trafficSignalConcept",
           "cardinality": "many",
           "inverse": true
         }
       },
       "new-resource-base": "http://data.lblod.info/traffic-measure-concepts/"
     },
-    "traffic-sign-concepts": {
-      "name": "trafficSignConcept",
+    "traffic-signal-concepts": {
+      "name": "trafficSignalConcept",
       "class": "mobiliteit:Verkeerstekenconcept",
       "super": ["skosConcept"],
       "attributes": {
@@ -446,12 +446,12 @@
           "cardinality": "many"
         }
       },
-      "new-resource-base": "http://data.lblod.info/traffic-sign-concepts/"
+      "new-resource-base": "http://data.lblod.info/traffic-signal-concepts/"
     },
     "road-sign-concepts": {
       "name": "roadSignConcept",
       "class": "mobiliteit:Verkeersbordconcept",
-      "super": ["trafficSignConcept"],
+      "super": ["trafficSignalConcept"],
       "attributes": {},
       "relationships": {
         "status": {
@@ -509,7 +509,7 @@
     "road-marking-concepts": {
       "name": "roadMarkingConcept",
       "class": "mobiliteit:Wegmarkeringconcept",
-      "super": ["trafficSignConcept"],
+      "super": ["trafficSignalConcept"],
       "attributes": {},
       "relationships": {
         "relatedToRoadMarkingConcepts": {
@@ -545,7 +545,7 @@
     "traffic-light-concepts": {
       "name": "trafficLightConcept",
       "class": "mobiliteit:Verkeerslichtconcept",
-      "super": ["trafficSignConcept"],
+      "super": ["trafficSignalConcept"],
       "attributes": {},
       "relationships": {
         "relatedToTrafficLightConcepts": {


### PR DESCRIPTION
### Overview
Changes the resources API but not the model.

##### connected issues and PRs:
Works with https://github.com/lblod/frontend-mow-registry/pull/337

### Setup
Needs to run with the new frontend to avoid breaking the traffic measures screen

### How to test/reproduce
In the traffic measures screen, the links to related signs/markings/lights work correctly.

### Challenges/uncertainties
I wasn't sure to change the base-url, but figure it shouldn't actually change anything as it's just a URI.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
