### PR TITLE
Update sparql-parser to `feature-construct-updates` tag

### DIFF
--- a/.changeset/loud-rivers-speak.md
+++ b/.changeset/loud-rivers-speak.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Update sparql-parser to `feature-construct-updates` tag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "logging=true"
     logging: *default-logging
   db:
-    image: semtech/sparql-parser:0.0.13
+    image: semtech/sparql-parser:feature-construct-updates
     volumes:
       - ./config/cl-authorization:/config
       - ./data/mu-auth:/data


### PR DESCRIPTION
### Overview
This PR introduces an update to the `feature-construct-updates` tag of sparql-parser.
It uses `CONSTRUCT` queries when deleting and inserting data instead of relying on `OPTIONAL` statements.
This will hopefully resolve the issue where deleting road-signs fails, but that issue is quite hard to reproduce. 

It seems to happen on road-signs with a lot of properties/relationships, but even then this is not guaranteed. 
##### connected issues and PRs:
[GN-5637](https://binnenland.atlassian.net/browse/GN-5637?atlOrigin=eyJpIjoiZDY0MGQ3Y2ExYTViNDhiYmIxOWEzZTE0ZDQxOTJkZDciLCJwIjoiaiJ9)


### How to test/reproduce
- Start the app
- Ensure editing/adding/removing concepts/codelist/icons still works

**Reproducing the delete-road-sign bug/issue**
- Create a road-sign concept with a lot of properties and relationships + create backup of the DB
- Set-up the stack with sparql-parser version 0.0.13 or 0.0.14
- Try to delete the road-sign, it will take a while or fail (silently)
- Restore the backup
- Set-up the stack with sparql-parser tag `feature-construct-updates` 
- Deleting the road-sign should now happen instantly and correctly

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
