### PR TITLE
add inverse to support pagination in shapes and variables

### DIFF
--- a/.changeset/curly-points-impress.md
+++ b/.changeset/curly-points-impress.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Add inverse relationship to support pagination on variables and shapes

--- a/config/migrations/20250923124700-fix-height-and-width-shape.sparql
+++ b/config/migrations/20250923124700-fix-height-and-width-shape.sparql
@@ -1,0 +1,77 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX icb: <https://w3id.org/isCharacterisedBy#>
+    PREFIX cidoc: <http://www.cidoc-crm.org/cidoc-crm/>
+    PREFIX qudt: <http://qudt.org/schema/qudt/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    PREFIX tribont: <https://w3id.org/tribont/core#>
+INSERT {
+  GRAPH ?g {
+    ?shape cidoc:P43_has_dimension ?newDimensionUri.
+    ?newDimensionUri a cidoc:E54_Dimension;
+      rdf:value "0";
+      mu:uuid ?newDimensionUuid;
+      qudt:hasQuantityKind <http://qudt.org/vocab/quantitykind/Height>;
+      qudt:hasUnit ?unit.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?shape a tribont:Shape;
+      cidoc:P2_has_type ?shapeType;
+      cidoc:P43_has_dimension ?dimensionTwo.
+  
+    FILTER NOT EXISTS {
+      ?shape cidoc:P43_has_dimension ?dimension.
+      ?dimension qudt:hasQuantityKind ?dimensionType
+    }
+
+    ?dimensionTwo qudt:hasUnit ?unit.
+  
+  VALUES ?shapeType {
+    <http://data.lblod.info/concept-schemes/a5a1b947-1c34-40df-8842-707de418adb8>
+    <http://data.lblod.info/concept-schemes/4f445b8f-98ce-4621-b671-009a1acb13a6>
+    <http://data.lblod.info/concept-schemes/10b19729-8b4a-4ea5-8470-bc34fc204791>
+    <http://lblod.data.gift/concept-schemes/1cddd186-6018-4d12-84d6-f1a5d01affde>
+  }
+  VALUES ?dimensionType {
+    <http://qudt.org/vocab/quantitykind/Height>
+  }
+  bind(strUUID() as ?newDimensionUuid)
+  bind(IRI(concat("http://data.lblod.info/dimensions/", ?newDimensionUuid)) as ?newDimensionUri)
+}
+}
+
+INSERT {
+  GRAPH ?g {
+    ?shape cidoc:P43_has_dimension ?newDimensionUri.
+    ?newDimensionUri a cidoc:E54_Dimension;
+      rdf:value "0";
+      mu:uuid ?newDimensionUuid;
+      qudt:hasQuantityKind <http://qudt.org/vocab/quantitykind/Width>;
+      qudt:hasUnit ?unit.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?shape a tribont:Shape;
+      cidoc:P2_has_type ?shapeType;
+      cidoc:P43_has_dimension ?dimensionTwo.
+  
+    FILTER NOT EXISTS {
+      ?shape cidoc:P43_has_dimension ?dimension.
+      ?dimension qudt:hasQuantityKind ?dimensionType
+    }
+
+    ?dimensionTwo qudt:hasUnit ?unit.
+  
+  VALUES ?shapeType {
+    <http://data.lblod.info/concept-schemes/a5a1b947-1c34-40df-8842-707de418adb8>
+    <http://data.lblod.info/concept-schemes/4f445b8f-98ce-4621-b671-009a1acb13a6>
+    <http://data.lblod.info/concept-schemes/10b19729-8b4a-4ea5-8470-bc34fc204791>
+    <http://lblod.data.gift/concept-schemes/1cddd186-6018-4d12-84d6-f1a5d01affde>
+  }
+  VALUES ?dimensionType {
+    <http://qudt.org/vocab/quantitykind/Width>
+  }
+  bind(strUUID() as ?newDimensionUuid)
+  bind(IRI(concat("http://data.lblod.info/dimensions/", ?newDimensionUuid)) as ?newDimensionUri)
+}
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -16,6 +16,7 @@
     "qudt": "http://qudt.org/schema/qudt/",
     "variables": "http://lblod.data.gift/vocabularies/variables/",
     "schema": "http://schema.org/"
+    "dct": "http://lblod.data.gift/vocabularies/variables/"
   },
   "resources": {
     "resources": {
@@ -251,6 +252,10 @@
         "defaultValue": {
           "type": "string",
           "predicate": "variables:defaultValue"
+        },
+        "created-on": {
+          "type": "datetime",
+          "predicate": "dct:created"
         }
       },
       "relationships": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -15,7 +15,7 @@
     "foaf": "http://xmlns.com/foaf/0.1/",
     "qudt": "http://qudt.org/schema/qudt/",
     "variables": "http://lblod.data.gift/vocabularies/variables/",
-    "schema": "http://schema.org/"
+    "schema": "http://schema.org/",
     "dct": "http://lblod.data.gift/vocabularies/variables/"
   },
   "resources": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -269,7 +269,7 @@
           "target": "template",
           "cardinality": "one"
         },
-        "trafficSignalConcept": {
+        "traffic-signal-concept": {
           "predicate": "mobiliteit:variabele",
           "target": "trafficSignalConcept",
           "cardinality": "one",
@@ -366,7 +366,7 @@
           "target": "dimension",
           "cardinality": "many"
         },
-        "trafficSignalConcept": {
+        "traffic-signal-concept": {
           "predicate": "icb:isCharacterisedBy",
           "target": "trafficSignalConcept",
           "cardinality": "one",

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -262,6 +262,12 @@
           "predicate": "mobiliteit:template",
           "target": "template",
           "cardinality": "one"
+        },
+        "trafficSignalConcept": {
+          "predicate": "mobiliteit:variabele",
+          "target": "trafficSignalConcept",
+          "cardinality": "one",
+          "inverse": true
         }
       },
       "features": ["include-uri"],
@@ -302,6 +308,7 @@
           "target": "unit"
         }
       },
+      "features": ["include-uri"],
       "new-resource-base": "http://data.lblod.info/quantitykind/"
     },
     "dimensions": {
@@ -347,8 +354,15 @@
           "predicate": "cidoc:P43_has_dimension",
           "target": "dimension",
           "cardinality": "many"
+        },
+        "trafficSignalConcept": {
+          "predicate": "icb:isCharacterisedBy",
+          "target": "trafficSignalConcept",
+          "cardinality": "one",
+          "inverse": true
         }
       },
+      "features": ["include-uri"],
       "new-resource-base": "http://data.lblod.info/tribont-shapes/"
     },
     "traffic-measure-concepts": {

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -269,7 +269,7 @@
           "target": "template",
           "cardinality": "one"
         },
-        "traffic-signal-concept": {
+        "trafficSignalConcept": {
           "predicate": "mobiliteit:variabele",
           "target": "trafficSignalConcept",
           "cardinality": "one",
@@ -366,7 +366,7 @@
           "target": "dimension",
           "cardinality": "many"
         },
-        "traffic-signal-concept": {
+        "trafficSignalConcept": {
           "predicate": "icb:isCharacterisedBy",
           "target": "trafficSignalConcept",
           "cardinality": "one",

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -349,7 +349,12 @@
     "tribont-shapes": {
       "name": "tribontShape",
       "class": "tribont:Shape",
-      "attributes": {},
+      "attributes": {
+        "created-on": {
+          "type": "datetime",
+          "predicate": "dct:created"
+        }
+      },
       "relationships": {
         "classification": {
           "predicate": "cidoc:P2_has_type",


### PR DESCRIPTION
### Overview
Add inverse for traffic sign concept for shapes and variables to support pagination

##### connected issues and PRs:
GN-5692
https://github.com/lblod/frontend-mow-registry/pull/346


### Setup
Use with the frontend PR https://github.com/lblod/frontend-mow-registry/pull/346

### How to test/reproduce
Check that the pagination works on the frontend

### Challenges/uncertainties
None



### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
