### PR TITLE
Update mu-cl-resources to `feature-always-assume-lockless-hashtables` tag

### DIFF
--- a/.changeset/tame-months-count.md
+++ b/.changeset/tame-months-count.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": patch
+---
+
+Update `mu-cl-resources` service to `feature-always-assume-lockless-hashtables` tag. This tag fixes issues with failing DELETE requests introduced in version 1.27.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     # since it is a rather clear bugfix
     # So, either verify the patch still works (ask @abeforgit for context) or
     # remove it if you've confirmed the fix is in the new version
-    image: semtech/mu-cl-resources:1.27.0
+    image: semtech/mu-cl-resources:feature-always-assume-lockless-hashtables
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     links:


### PR DESCRIPTION
### Overview
Update `mu-cl-resources` service to `feature-always-assume-lockless-hashtables` tag. This tag fixes issues with failing DELETE requests introduced in version 1.27.0

##### connected issues and PRs:
https://github.com/mu-semtech/mu-cl-resources/tree/feature/always-assume-lockless-hashtables

### How to test/reproduce
**With version 1.27.0 configured**
- Start the app
- Open a road-sign
- Try to remove it, this should fail

**With the `feature-always-assume-lockless-hashtables` tag configured**
- Removing a road-sign should succeed

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
