### PR TITLE
GN-5726 (part 2): set-up ember-metis

### DIFF
--- a/.changeset/blue-lobsters-beam.md
+++ b/.changeset/blue-lobsters-beam.md
@@ -1,0 +1,5 @@
+---
+"app-mow-registry": minor
+---
+
+Set-up ember-metis services

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -174,6 +174,17 @@ defmodule Dispatcher do
   end
 
   ###############################################################
+  # metis
+  ###############################################################
+  get "/uri-info/*path", %{ accept: %{ json: true } } do
+    forward conn, path, "http://uri-info/"
+  end
+
+  get "/resource-labels/*path", %{ accept: %{ json: true } } do
+    forward conn, path, "http://resource-labels-cache/"
+  end
+
+  ###############################################################
   # login specific
   ###############################################################
   match "/mock/sessions/*path", %{ accept: %{any: true}, layer: :api} do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,5 +238,7 @@ services:
       - db:database
   resource-labels:
     image: lblod/resource-label-service:0.3.2
+    environment:
+      DEFAULT_LANGUAGE: nil
     links:
       - db:database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -227,3 +227,16 @@ services:
     image: lblod/mow-ordered-signs-service:1.0.1
     links:
       - triplestore:database
+  uri-info:
+    image: redpencil/mu-uri-info-service:0.2.1
+    links:
+      - db:database
+  resource-labels-cache:
+    image: semtech/mu-cache:2.0.2
+    links:
+      - resource-labels:backend
+      - db:database
+  resource-labels:
+    image: lblod/resource-label-service:0.3.2
+    links:
+      - db:database


### PR DESCRIPTION
### Overview
This (draft) PR sets-up the services and dispatcher rules to get ember-metis to work:
- `uri-info` (https://github.com/redpencilio/mu-uri-info-service/): looks up the outgoing and incoming triples for a certain uri/subject
- `resource-labels` (https://github.com/lblod/resource-label-service): looks up the label for a certain uri (rdfs:label or skos:prefLabel)
- `resource-labels-cache`: a cache for the `resource-labels` service


##### connected issues and PRs:
[GN-5726](https://binnenland.atlassian.net/browse/GN-5726?atlOrigin=eyJpIjoiZGQyNGRlOWJmNTk5NGI1YTkzMDM4MWY2NDFiZGFkNjEiLCJwIjoiaiJ9)
https://github.com/lblod/frontend-mow-registry/pull/352

### Setup
Ensure you are running https://github.com/lblod/frontend-mow-registry/pull/352 as the frontend

### How to test/reproduce
Note: we currently don't have URIs with the http://register.mobiliteit.vlaanderen.be/ base yet, if you want to test metis with another base, you can do so by adjusting the URI base metis discovers in the frontend.

- For a specific resource you want to see the metis page for, take the part after `<configured-metis-uri-base>`, and add it to the url you are running the frontend on.
  E.g. `<configured-metis-uri-base>/concepts/1` becomes `http://localhost:4200/concepts/1`
- This url should lead you to the metis page, where you can see more info and the incoming/outgoing relationships of that resource

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
